### PR TITLE
chore: update AGENTS requirements and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ reports/
 
 # Node/npm
 node_modules/
-.worktrees/
+.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ reports/
 
 # Node/npm
 node_modules/
-.worktrees
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,7 @@ All agents must follow these rules:
    - Common: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, `perf:`
    - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
 3) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
-4) PR descriptions must include `Summary`, `Rationale`, and `Details` sections.
+4) PR descriptions must include Summary, Rationale, and Details sections.
 5) Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.
-
-Reference: https://www.conventionalcommits.org/en/v1.0.0/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ All agents must follow these rules:
    - Common: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, `perf:`
    - Support titles: `fix(docs):`, `fix(benchmarks):`, `fix(cicd):`
 3) Commit messages must follow the same Conventional Commits-style prefixes and include a short functional description plus a user-facing value proposition.
-4) PR descriptions must include Summary, Rationale, and Details sections.
+4) PR descriptions must include `Summary`, `Rationale`, and `Details` sections.
 5) Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,7 @@ All agents must follow these rules:
 5) Run relevant Python tests for changes (pytest/unittest or the repo's configured runner).
 6) Follow formatting/linting configured in pyproject.toml, setup.cfg, tox.ini, or ruff.toml.
 7) Update dependency lockfiles when adding or removing Python dependencies.
+8) Maximize the use of caching in GitHub workflow files to minimize run duration.
+9) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
+
+Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary
- Update `AGENTS.md` to reflect current contributor requirements.
- Add `.worktrees/` to `.gitignore`.

Rationale
- Keep contributor guidance consistent across repos.
- Avoid accidental commits of local worktree directories.

Details
- Applies the latest agent requirement rules for this repo.
- Ignores local worktree directories used during validation.